### PR TITLE
Move `midpoint` to `PrimitiveNumber`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-primitive"
-version = "0.2.3"
+version = "0.3.0"
 description = "Traits for primitive numeric types"
 repository = "https://github.com/rust-num/num-primitive"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-primitive.svg)](https://crates.io/crates/num-primitive)
 [![documentation](https://docs.rs/num-primitive/badge.svg)](https://docs.rs/num-primitive)
-[![minimum rustc 1.85](https://img.shields.io/badge/rustc-1.85+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.87](https://img.shields.io/badge/rustc-1.87+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/rust-num/num-primitive/workflows/CI/badge.svg)](https://github.com/rust-num/num-primitive/actions)
 
 Traits for primitive numeric types in Rust.
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-primitive = "0.2"
+num-primitive = "0.3"
 ```
 
 ## Features
@@ -48,7 +48,7 @@ the default `std` feature. Use this in `Cargo.toml`:
 
 ```toml
 [dependencies.num-primitive]
-version = "0.2"
+version = "0.3"
 default-features = false
 ```
 
@@ -61,7 +61,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-primitive` crate is currently tested for Rust 1.85 and greater. This
+The `num-primitive` crate is currently tested for Rust 1.87 and greater. This
 minimum-supported Rust version (MSRV) may be increased at any time to add
 support for newly-stabilized functionality from the standard library. Changes
 will be documented prominently in the release notes.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+# Release 0.3.0 (2025-12-16)
+
+- Added `PrimitiveNumber::midpoint`
+- Removed `Primitive{Float,Signed,Unsigned}::midpoint`
+
 # Release 0.2.3 (2025-12-16)
 
 - Updated to MSRV 1.87.

--- a/src/float.rs
+++ b/src/float.rs
@@ -218,9 +218,6 @@ pub trait PrimitiveFloat:
     /// Returns the maximum of the two numbers, ignoring NaN.
     fn max(self, other: Self) -> Self;
 
-    /// Calculates the middle point of `self` and `other`.
-    fn midpoint(self, other: Self) -> Self;
-
     /// Returns the minimum of the two numbers, ignoring NaN.
     fn min(self, other: Self) -> Self;
 
@@ -527,7 +524,6 @@ macro_rules! impl_float {
                 fn is_sign_positive(self) -> bool;
                 fn is_subnormal(self) -> bool;
                 fn max(self, other: Self) -> Self;
-                fn midpoint(self, other: Self) -> Self;
                 fn min(self, other: Self) -> Self;
                 fn next_down(self) -> Self;
                 fn next_up(self) -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! num-primitive = "0.2"
+//! num-primitive = "0.3"
 //! ```
 //!
 //! ## Features
@@ -43,7 +43,7 @@
 //!
 //! ```toml
 //! [dependencies.num-primitive]
-//! version = "0.2"
+//! version = "0.3"
 //! default-features = false
 //! ```
 //!

--- a/src/number.rs
+++ b/src/number.rs
@@ -129,6 +129,9 @@ pub trait PrimitiveNumber:
     /// Creates a number from its representation as a byte array in native endian.
     fn from_ne_bytes(bytes: Self::Bytes) -> Self;
 
+    /// Calculates the midpoint (average) between `self` and `other`.
+    fn midpoint(self, other: Self) -> Self;
+
     /// Returns the memory representation of this number as a byte array in little-endian order.
     fn to_be_bytes(self) -> Self::Bytes;
 
@@ -272,6 +275,7 @@ macro_rules! impl_primitive {
                 fn from_ne_bytes(bytes: Self::Bytes) -> Self;
             }
             forward! {
+                fn midpoint(self, other: Self) -> Self;
                 fn to_be_bytes(self) -> Self::Bytes;
                 fn to_le_bytes(self) -> Self::Bytes;
                 fn to_ne_bytes(self) -> Self::Bytes;

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -83,9 +83,6 @@ pub trait PrimitiveSigned: PrimitiveInteger + From<i8> + core::ops::Neg<Output =
     /// Returns true if `self` is positive and false if the number is zero or negative.
     fn is_positive(self) -> bool;
 
-    /// Calculates the middle point of `self` and `other`.
-    fn midpoint(self, other: Self) -> Self;
-
     /// Computes the absolute value of `self`. Returns a tuple of the absolute version of `self`
     /// along with a boolean indicating whether an overflow happened.
     fn overflowing_abs(self) -> (Self, bool);
@@ -154,7 +151,6 @@ macro_rules! impl_signed {
                 fn checked_sub_unsigned(self, rhs: Self::Unsigned) -> Option<Self>;
                 fn is_negative(self) -> bool;
                 fn is_positive(self) -> bool;
-                fn midpoint(self, other: Self) -> Self;
                 fn overflowing_abs(self) -> (Self, bool);
                 fn overflowing_add_unsigned(self, rhs: Self::Unsigned) -> (Self, bool);
                 fn overflowing_sub_unsigned(self, rhs: Self::Unsigned) -> (Self, bool);

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -65,9 +65,6 @@ pub trait PrimitiveUnsigned: PrimitiveInteger + From<u8> {
     /// Returns `true` if and only if `self == 2^k` for some `k`.
     fn is_power_of_two(self) -> bool;
 
-    /// Calculates the middle point of `self` and `other`.
-    fn midpoint(self, other: Self) -> Self;
-
     /// Calculates the smallest value greater than or equal to `self` that is a multiple of `rhs`.
     fn next_multiple_of(self, rhs: Self) -> Self;
 
@@ -107,7 +104,6 @@ macro_rules! impl_unsigned {
                 fn div_ceil(self, rhs: Self) -> Self;
                 fn is_multiple_of(self, rhs: Self) -> bool;
                 fn is_power_of_two(self) -> bool;
-                fn midpoint(self, other: Self) -> Self;
                 fn next_multiple_of(self, rhs: Self) -> Self;
                 fn next_power_of_two(self) -> Self;
                 fn overflowing_add_signed(self, rhs: Self::Signed) -> (Self, bool);


### PR DESCRIPTION
This method became common to all primitive numeric types as of Rust 1.87, but it's a breaking change for us to push that up to our supertrait, so this will be release 0.3.0.