### PR TITLE
Specify error types where possible

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -3,7 +3,7 @@ use crate::{PrimitiveNumber, PrimitiveNumberRef, PrimitiveUnsigned};
 use core::cmp::Ordering;
 use core::f32::consts as f32_consts;
 use core::f64::consts as f64_consts;
-use core::num::FpCategory;
+use core::num::{FpCategory, ParseFloatError};
 
 struct SealedToken;
 
@@ -70,6 +70,7 @@ pub trait PrimitiveFloat:
     + core::convert::From<i8>
     + core::convert::From<u8>
     + core::ops::Neg<Output = Self>
+    + core::str::FromStr<Err = ParseFloatError>
 {
     /// Approximate number of significant digits in base 10.
     const DIGITS: u32;

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -128,6 +128,7 @@ pub trait PrimitiveInteger:
     + core::ops::ShrAssign<u64>
     + core::ops::ShrAssign<u128>
     + core::ops::ShrAssign<usize>
+    + core::str::FromStr<Err = ParseIntError>
     + for<'a> core::ops::BitAnd<&'a Self, Output = Self>
     + for<'a> core::ops::BitAndAssign<&'a Self>
     + for<'a> core::ops::BitOr<&'a Self, Output = Self>

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 use crate::{PrimitiveInteger, PrimitiveIntegerRef, PrimitiveUnsigned};
 
 /// Trait for all primitive [signed integer types], including the supertraits [`PrimitiveInteger`]
@@ -49,7 +51,12 @@ use crate::{PrimitiveInteger, PrimitiveIntegerRef, PrimitiveUnsigned};
 /// assert_eq!(extended_gcd::<i16>(1071, -462), (21, -3, -7));
 /// assert_eq!(extended_gcd::<i64>(6_700_417, 2_147_483_647), (1, 715_828_096, -2_233_473));
 /// ```
-pub trait PrimitiveSigned: PrimitiveInteger + From<i8> + core::ops::Neg<Output = Self> {
+pub trait PrimitiveSigned:
+    PrimitiveInteger
+    + core::convert::From<i8>
+    + core::convert::TryFrom<i8, Error = Infallible>
+    + core::ops::Neg<Output = Self>
+{
     /// The unsigned integer type used by methods like [`abs_diff`][Self::abs_diff] and
     /// [`checked_add_unsigned`][Self::checked_add_unsigned].
     type Unsigned: PrimitiveUnsigned;

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 use crate::{PrimitiveInteger, PrimitiveIntegerRef, PrimitiveSigned};
 
 /// Trait for all primitive [unsigned integer types], including the supertraits
@@ -32,7 +34,7 @@ use crate::{PrimitiveInteger, PrimitiveIntegerRef, PrimitiveSigned};
 /// assert_eq!(gcd::<u16>(1071, 462), 21);
 /// assert_eq!(gcd::<u32>(6_700_417, 2_147_483_647), 1);
 /// ```
-pub trait PrimitiveUnsigned: PrimitiveInteger + From<u8> {
+pub trait PrimitiveUnsigned: PrimitiveInteger + From<u8> + TryFrom<u8, Error = Infallible> {
     /// The signed integer type used by methods like
     /// [`checked_add_signed`][Self::checked_add_signed].
     type Signed: PrimitiveSigned;


### PR DESCRIPTION
We can't name a specific error type in `PrimitiveNumber: FromStr` because it's different between floats and ints. However, we **can** refine that in `PrimitiveFloat` and `PrimitiveInteger` to specify their respective error types.

Similarly, `PrimitiveInteger: TryFrom<_>` is not specific because the error could be `Infallible` or `TryFromIntError`. In the cases of `PrimitiveSigned: TryFrom<i8>` and `PrimitiveUnsigned: TryFrom<u8>` though, we do know they are always `Infallible` -- which is implied by their respective `From`, but needs to be explicit.