### PR TITLE
Release 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-primitive"
-version = "0.3.3"
+version = "0.3.4"
 description = "Traits for primitive numeric types"
 repository = "https://github.com/rust-num/num-primitive"
 license = "MIT OR Apache-2.0"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.3.4 (2025-12-20)
+
+- Added `PrimitiveInteger::from_str_radix`.
+- Specified error types in `PrimitiveInteger: FromStr`, `PrimitiveSigned: TryFrom<i8>`,
+  and `PrimitiveUnsigned: TryFrom<u8>`.
+
 # Release 0.3.3 (2025-12-17)
 
 - Added `PrimitiveBytes` to consolidate the constraints on `PrimitiveNumber::Bytes`


### PR DESCRIPTION
- Added `PrimitiveInteger::from_str_radix`.
- Specified error types in `PrimitiveInteger: FromStr`, `PrimitiveSigned: TryFrom<i8>`,
  and `PrimitiveUnsigned: TryFrom<u8>`.