### PR TITLE
Release 0.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   merge_group:
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-primitive"
-version = "0.2.3"
+version = "0.2.4"
 description = "Traits for primitive numeric types"
 repository = "https://github.com/rust-num/num-primitive"
 license = "MIT OR Apache-2.0"
@@ -8,6 +8,10 @@ keywords = ["generic", "mathematics", "numerics", "primitive"]
 categories = ["algorithms", "science", "no-std"]
 edition = "2024"
 rust-version = "1.87"
+
+[package.metadata.release]
+allow-branch = ["main"]
+sign-tag = true
 
 [features]
 default = ["std"]
@@ -24,7 +28,3 @@ unreachable-pub = "deny"
 [lints.rustdoc]
 broken-intra-doc-links = "deny"
 private-intra-doc-links = "deny"
-
-[package.metadata.release]
-allow-branch = ["main"]
-sign-tag = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-primitive.svg)](https://crates.io/crates/num-primitive)
 [![documentation](https://docs.rs/num-primitive/badge.svg)](https://docs.rs/num-primitive)
-[![minimum rustc 1.85](https://img.shields.io/badge/rustc-1.85+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.87](https://img.shields.io/badge/rustc-1.87+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/rust-num/num-primitive/workflows/CI/badge.svg)](https://github.com/rust-num/num-primitive/actions)
 
 Traits for primitive numeric types in Rust.
@@ -61,7 +61,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-primitive` crate is currently tested for Rust 1.85 and greater. This
+The `num-primitive` crate is currently tested for Rust 1.87 and greater. This
 minimum-supported Rust version (MSRV) may be increased at any time to add
 support for newly-stabilized functionality from the standard library. Changes
 will be documented prominently in the release notes.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# Release 0.2.4 (2025-12-20)
+
+- Backported `PrimitiveInteger::from_str_radix` from 0.3.4.
+
 # Release 0.2.3 (2025-12-16)
 
 - Updated to MSRV 1.87.

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,3 +1,5 @@
+use core::num::ParseIntError;
+
 use crate::{PrimitiveError, PrimitiveNumber, PrimitiveNumberRef};
 
 /// Trait for all primitive [integer types], including the supertrait [`PrimitiveNumber`].
@@ -262,6 +264,9 @@ pub trait PrimitiveInteger:
 
     /// Converts an integer from little endian to the target's endianness.
     fn from_le(value: Self) -> Self;
+
+    /// Parses an integer from a string slice with digits in a given base.
+    fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError>;
 
     /// Returns the logarithm of the number with respect to an arbitrary base, rounded down.
     fn ilog(self, base: Self) -> u32;
@@ -543,6 +548,7 @@ macro_rules! impl_integer {
             forward! {
                 fn from_be(value: Self) -> Self;
                 fn from_le(value: Self) -> Self;
+                fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError>;
             }
             forward! {
                 fn checked_add(self, rhs: Self) -> Option<Self>;


### PR DESCRIPTION
- Backported `PrimitiveInteger::from_str_radix` from 0.3.4.